### PR TITLE
gh-4 save summary metadata to data class as well as data element

### DIFF
--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/mysql/MySqlDatabaseDataModelImporterProviderServiceTest.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/mysql/MySqlDatabaseDataModelImporterProviderServiceTest.groovy
@@ -349,5 +349,16 @@ class MySqlDatabaseDataModelImporterProviderServiceTest extends BaseDatabasePlug
                 assertEquals "Value of summary metadatdata for ${columnName}", expectedReportValue, de.summaryMetadata[0].summaryMetadataReports[0].reportValue
             }
         }
+
+        //All data element summary metadata should also have been added to the data class
+        organisationTable.dataElements.each {dataElement ->
+            dataElement.summaryMetadata?.each {dataElementSummaryMetadata ->
+                assert 'dataElement summaryMetadata is also on the dataClass',
+                        organisationTable.summaryMetadata.find{organisationTableSummaryMetadata ->
+                    organisationTableSummaryMetadata.description == dataElementSummaryMetadata.description &&
+                    organisationTableSummaryMetadata.summaryMetadataReports[0].reportValue == dataElementSummaryMetadata.summaryMetadataReports[0].reportValue
+                }
+            }
+        }
     }
 }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/mysql/MySqlDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/mysql/MySqlDatabaseDataModelImporterProviderService.groovy
@@ -236,7 +236,11 @@ class MySqlDatabaseDataModelImporterProviderService
                                         description = "Estimated Enumeration Value Distribution (calculated by sampling ${samplingStrategy.percentage}% of rows)"
                                     }
                                     SummaryMetadata enumerationSummaryMetadata = SummaryMetadataHelper.createSummaryMetadataFromMap(user, de.label, description, enumerationValueDistribution)
-                                    de.addToSummaryMetadata(enumerationSummaryMetadata);
+                                    de.addToSummaryMetadata(enumerationSummaryMetadata)
+
+                                    SummaryMetadata enumerationSummaryMetadataOnTable =
+                                            SummaryMetadataHelper.createSummaryMetadataFromMap(user, de.label, description, enumerationValueDistribution)
+                                    tableClass.addToSummaryMetadata(enumerationSummaryMetadataOnTable)
                                 }
                             }
                         }
@@ -251,12 +255,15 @@ class MySqlDatabaseDataModelImporterProviderService
 
                                 Map<String, Long> valueDistribution = getColumnRangeDistribution(connection, samplingStrategy, dt, intervalHelper, de.label, tableClass.label)
                                 if (valueDistribution) {
-                                    String description = 'Value Distribution';
+                                    String description = 'Value Distribution'
                                     if (samplingStrategy.useSampling()) {
                                         description = "Estimated Value Distribution (calculated by sampling ${samplingStrategy.percentage}% of rows)"
                                     }
                                     SummaryMetadata summaryMetadata = SummaryMetadataHelper.createSummaryMetadataFromMap(user, de.label, description, valueDistribution)
-                                    de.addToSummaryMetadata(summaryMetadata);
+                                    de.addToSummaryMetadata(summaryMetadata)
+
+                                    SummaryMetadata summaryMetadataOnTable = SummaryMetadataHelper.createSummaryMetadataFromMap(user, de.label, description, valueDistribution)
+                                    tableClass.addToSummaryMetadata(summaryMetadataOnTable)
                                 }
                             }
                         }


### PR DESCRIPTION
Closes #4 

- When saving summary metadata to a data element, save a copy of the same summary metadata to the data class to which the data element belongs.
- Add tests to verify the save to the data class